### PR TITLE
GetControllers compatible for custom implementation

### DIFF
--- a/Xpand/Xpand.Persistent/Xpand.Persistent.Base/General/FrameExtensions.cs
+++ b/Xpand/Xpand.Persistent/Xpand.Persistent.Base/General/FrameExtensions.cs
@@ -48,9 +48,8 @@ namespace Xpand.Persistent.Base.General {
         }
 
         public static IEnumerable<T> GetControllers<T>(this Frame frame) where T:Controller {
-            foreach (var controller in frame.Controllers){
-                var controllers = controller as T;
-                if (controllers != null)
+            foreach (var controller in frame.GetControllers(typeof(T))) {
+                if (controller is T controllers)
                     yield return controllers;
             }
         }


### PR DESCRIPTION
Making the FrameExtensions.GetControllers<T> compatible for custom implementations with interfaces or classes. See https://github.com/eXpandFramework/eXpand/issues/444 for more information